### PR TITLE
Simplify spline logic

### DIFF
--- a/src/morphosamplers/spline.py
+++ b/src/morphosamplers/spline.py
@@ -126,7 +126,7 @@ class NDimensionalSpline(EventedModel):
             raise ValueError("derivative order must be [0, spline_order]")
         u = np.atleast_1d(u)
         samples = splev(np.atleast_1d(u), self._tck)
-        return np.stack(samples, axis=1)
+        return np.stack(samples, axis=1) # (n, d)
 
     def _get_equidistance_u(self, separation: float) -> np.ndarray:
         """Get equally spaced values of u.

--- a/src/morphosamplers/spline.py
+++ b/src/morphosamplers/spline.py
@@ -82,7 +82,7 @@ class NDimensionalSpline(EventedModel):
         # prepend a zero, no distance has been covered
         # at start of spline parametrisation
         cumulative_distance = np.insert(cumulative_distance, 0, 0)
-        # save lenght for later and normalize
+        # save length for later and normalize
         self._length = cumulative_distance[-1]
         cumulative_distance /= self._length
 


### PR DESCRIPTION
I realized that we were overcomplicating things by keeping around 2 splines. Instead of parametrizing for `u`, we can directly parametrize for the points :P

If you want to quickly test to check that it's the same:

```python
import napari
import numpy as np
from morphosamplers.spline import Spline3D

v = napari.Viewer(ndisplay=3)
pts = np.random.rand(10, 3) * 100
pl = v.add_points(pts, face_color='r')

spline = Spline3D(pts)
v.add_points(spline.sample_spline(np.linspace(0, 1, 100)))
```
