### PR TITLE
Proposal to simplify spline sampling to one method

### DIFF
--- a/src/morphosamplers/sampler.py
+++ b/src/morphosamplers/sampler.py
@@ -169,7 +169,7 @@ def sample_volume_along_spline(
         Sampled volume.
     """
     u = np.linspace(0, 1, batch)
-    positions = spline.sample_spline(u)
+    positions = spline.sample(u)
     orientations = spline.sample_spline_orientations(u)
     grid = generate_2d_grid(grid_shape=grid_shape, grid_spacing=grid_spacing)
     sampling_coords = place_sampling_grids(grid, positions, orientations)

--- a/tests/test_spline_model.py
+++ b/tests/test_spline_model.py
@@ -33,12 +33,12 @@ def test_n_dimensional_spline(points, expected_points):
     assert spline_model.order == 4
 
     # test samping single point
-    sample_values = spline_model.sample_spline(0.5)
+    sample_values = spline_model.sample(0.5)
     expected_single_value = np.atleast_2d(expected_points[0])
     np.testing.assert_allclose(expected_single_value, sample_values)
 
     # test sampling array of points
-    sample_values = spline_model.sample_spline(u=[0.5, 1])
+    sample_values = spline_model.sample(u=[0.5, 1])
     np.testing.assert_allclose(expected_points, sample_values)
 
 
@@ -48,13 +48,13 @@ def test_update_spline_points():
     initial_points = np.array([[0, 0], [0.2, 0.2], [0.3, 0.3], [1, 1]])
     spline_model = NDimensionalSpline(points=initial_points, order=2)
 
-    value_initial_spline = spline_model.sample_spline(u=0.5)
+    value_initial_spline = spline_model.sample(u=0.5)
     np.testing.assert_allclose([[0.5, 0.5]], value_initial_spline)
 
     # line with slope 2
     updated_points = np.array([[0, 0], [0.2, 0.4], [0.3, 0.6], [1, 2]])
     spline_model.points = updated_points
-    value_updated_spline = spline_model.sample_spline(u=0.5)
+    value_updated_spline = spline_model.sample(u=0.5)
     np.testing.assert_allclose([[0.5, 1]], value_updated_spline)
 
 
@@ -70,12 +70,12 @@ def test_update_spline_order():
     spline_model = NDimensionalSpline(points=points, order=initial_spline_order)
 
     # get the value with the initial spline
-    value_initial_spline = spline_model.sample_spline(u=0.2)
+    value_initial_spline = spline_model.sample(u=0.2)
 
     # update the spline order and get value at the same point
     updated_spline_order = 4
     spline_model.order = updated_spline_order
-    value_updated_spline = spline_model.sample_spline(u=0.2)
+    value_updated_spline = spline_model.sample(u=0.2)
 
     with pytest.raises(AssertionError):
         # the updated value should be different because the spline is higher order
@@ -118,10 +118,10 @@ def test_invalid_spline_derivatives(derivative_order):
     spline_model = NDimensionalSpline(points=points, order=3)
 
     with pytest.raises(ValueError):
-        _ = spline_model.sample_spline(u=0, derivative_order=derivative_order)
+        _ = spline_model.sample(u=0, derivative_order=derivative_order)
 
     with pytest.raises(ValueError):
-        _ = spline_model._get_equidistance_spline_samples(
+        _ = spline_model.sample(
             separation=1, derivative_order=derivative_order
         )
 
@@ -129,7 +129,7 @@ def test_invalid_spline_derivatives(derivative_order):
 def test_spline_orientations():
     points = np.array([[0, 0, 0], [0, 0, 1], [0, 0, 2], [0, 0, 3]])
     spline = Spline3D(points=points, order=3)
-    pt = spline.sample_spline(u=0)
+    pt = spline.sample(u=0)
     # lower atol, as it's very strict by default, much more than np.allclose
     np.testing.assert_allclose(pt, 0, atol=1e-20)
     ori = spline.sample_spline_orientations(u=0)


### PR DESCRIPTION
After the changes in #8 the spline sampling logic is a bit clearer so I've condensed it down to one `sample()` method.

I feel like this API is overall simpler and a bit nicer but you could also say that the `sample()` method is a bit overloaded... I'll leave this here in case either of you have opinions but I think I prefer it!