### PR TITLE
move to morphomodels API

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,7 +1,8 @@
 include LICENSE
 include README.md
 include requirements.txt
+recursive-include examples
 
 recursive-exclude * __pycache__
 recursive-exclude * *.py[co]
-recursive-exclude examples
+

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,8 +1,8 @@
 include LICENSE
 include README.md
 include requirements.txt
-recursive-include examples
 
+recursive-include examples *.py
 recursive-exclude * __pycache__
 recursive-exclude * *.py[co]
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,3 +4,4 @@ include requirements.txt
 
 recursive-exclude * __pycache__
 recursive-exclude * *.py[co]
+recursive-exclude examples

--- a/examples/path.py
+++ b/examples/path.py
@@ -29,7 +29,7 @@ helical_poses = helical_pose_sampler.sample(path)  # poses related by 'twist' de
 ### visualise
 viewer = napari.Viewer(ndisplay=3)
 
-# just positions
+# positions
 viewer.add_points(positions, size=5)
 
 # parallel poses
@@ -52,7 +52,7 @@ viewer.add_vectors(
     name='parallel pose y',
 )
 
-# parallel poses
+# helical poses
 viewer.add_vectors(
     data=np.stack(
         [helical_poses.positions, helical_poses.orientations[:, :, 2]],

--- a/examples/path.py
+++ b/examples/path.py
@@ -1,0 +1,76 @@
+import numpy as np
+import napari
+from scipy.spatial.transform import Rotation as R
+
+from morphosamplers.models import MorphoModels
+from morphosamplers.samplers import path_samplers
+
+# create some control points for a path
+xyz = np.linspace([0, 0, 0], [0, 0, 200], num=10)
+xyz[:, :2] += np.random.normal(loc=0, scale=10, size=(10, 2))
+
+# make a Path model from these control points
+path = MorphoModels.Path(control_points=xyz)
+
+
+### create different types of samplers and use them to sample the path
+# points
+point_sampler = path_samplers.PointSampler(spacing=10)
+positions = point_sampler.sample(path)  # equally spaced positions
+
+# poses
+pose_sampler = path_samplers.PoseSampler(spacing=10)
+parallel_poses = pose_sampler.sample(path)  # equally spaces parallel poses
+
+# helical poses
+helical_pose_sampler = path_samplers.HelicalPoseSampler(spacing=10, twist=30)
+helical_poses = helical_pose_sampler.sample(path)  # poses related by 'twist' degrees
+
+### visualise
+viewer = napari.Viewer(ndisplay=3)
+
+# just positions
+viewer.add_points(positions, size=5)
+
+# parallel poses
+viewer.add_vectors(
+    data=np.stack(
+        [parallel_poses.positions, parallel_poses.orientations[:, :, 2]],
+        axis=1
+    ),
+    length=5,
+    edge_color='orange',
+    name='parallel pose z'
+)
+viewer.add_vectors(
+    np.stack(
+        [parallel_poses.positions, parallel_poses.orientations[:, :, 1]],
+        axis=1
+    ),
+    length=2,
+    edge_color='cornflowerblue',
+    name='parallel pose y',
+)
+
+# parallel poses
+viewer.add_vectors(
+    data=np.stack(
+        [helical_poses.positions, helical_poses.orientations[:, :, 2]],
+        axis=1
+    ),
+    length=5,
+    edge_color='orange',
+    name='helical pose z'
+)
+viewer.add_vectors(
+    np.stack(
+        [helical_poses.positions, helical_poses.orientations[:, :, 1]],
+        axis=1
+    ),
+    length=2,
+    edge_color='cornflowerblue',
+    name='helical pose y',
+)
+
+# run napari
+napari.run()

--- a/examples/path.py
+++ b/examples/path.py
@@ -1,17 +1,14 @@
 import numpy as np
 import napari
-from scipy.spatial.transform import Rotation as R
 
-from morphosamplers.models import MorphoModels
-from morphosamplers.samplers import path_samplers
+from morphosamplers import Path, path_samplers
 
 # create some control points for a path
 xyz = np.linspace([0, 0, 0], [0, 0, 200], num=10)
 xyz[:, :2] += np.random.normal(loc=0, scale=10, size=(10, 2))
 
 # make a Path model from these control points
-path = MorphoModels.Path(control_points=xyz)
-
+path = Path(control_points=xyz)
 
 ### create different types of samplers and use them to sample the path
 # points

--- a/examples/sphere.py
+++ b/examples/sphere.py
@@ -1,0 +1,40 @@
+import napari
+import numpy as np
+
+from morphosamplers import MorphoModels, sphere_samplers
+
+# create a sphere model
+sphere = MorphoModels.Sphere(center=(5, 5, 5), radius=20)
+
+# create different types of samplers and use them to sample the sphere
+# points
+point_sampler = sphere_samplers.PointSampler(spacing=2)
+points = point_sampler.sample(sphere)
+
+# poses, z vector normal to the sphere
+pose_sampler = sphere_samplers.PoseSampler(spacing=2)
+poses = pose_sampler.sample(sphere)
+
+
+# visualise
+viewer = napari.Viewer(ndisplay=3)
+viewer.add_points(poses.positions)
+viewer.add_vectors(
+    data=np.stack(
+        [poses.positions, poses.orientations[:, :, 2]],
+        axis=1
+    ),
+    length=5,
+    edge_color='orange',
+    name='pose z'
+)
+viewer.add_vectors(
+    np.stack(
+        [poses.positions, poses.orientations[:, :, 1]],
+        axis=1
+    ),
+    length=2,
+    edge_color='cornflowerblue',
+    name='pose y',
+)
+napari.run()

--- a/examples/sphere.py
+++ b/examples/sphere.py
@@ -1,7 +1,7 @@
 import napari
 import numpy as np
 
-from morphosamplers import MorphoModels, sphere_samplers
+from morphosamplers import Sphere, sphere_samplers
 
 # create a sphere model
 sphere = MorphoModels.Sphere(center=(5, 5, 5), radius=20)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
     "psygnal",
     "pydantic",
     "scipy",
+    "typing-extensions"
 ]
 
 # extras

--- a/src/morphosamplers/__init__.py
+++ b/src/morphosamplers/__init__.py
@@ -8,3 +8,6 @@ except PackageNotFoundError:
     __version__ = "uninstalled"
 __author__ = "Kevin Yamauchi"
 __email__ = "kevin.yamauchi@gmail.com"
+
+from morphosamplers.models import MorphoModels
+from morphosamplers.samplers import path_samplers, sphere_samplers

--- a/src/morphosamplers/__init__.py
+++ b/src/morphosamplers/__init__.py
@@ -9,5 +9,5 @@ except PackageNotFoundError:
 __author__ = "Kevin Yamauchi"
 __email__ = "kevin.yamauchi@gmail.com"
 
-from morphosamplers.models import MorphoModels
+from morphosamplers.models import Path, Sphere, Surface
 from morphosamplers.samplers import path_samplers, sphere_samplers

--- a/src/morphosamplers/core.py
+++ b/src/morphosamplers/core.py
@@ -1,0 +1,34 @@
+from abc import abstractmethod
+from typing import TypeVar, Protocol, Generic
+
+from pydantic.generics import GenericModel
+
+M = TypeVar("M", bound="MorphoModel")
+S = TypeVar("S")
+
+
+class MorphoModel(GenericModel, Generic[M]):
+    """A set of attributes defining a geometrical support."""
+
+    class Config:
+        allow_mutation = False
+        arbitrary_types_allowed = True
+
+
+class SamplerProtocol(Protocol[M, S]):
+    """Protocol for classes that sample a `MorphoModel`."""
+
+    @abstractmethod
+    def sample(self, obj: M, *args) -> S:
+        """Sample a `MorphoModel` to produces samples of `Sa`."""
+        ...
+
+
+SamplerType = TypeVar("SamplerType", bound=SamplerProtocol)
+
+
+class MorphoSampler(GenericModel, Generic[SamplerType]):
+    """Concrete samplers should subclass this generic model."""
+
+    class Config:
+        allow_mutation = False

--- a/src/morphosamplers/models/__init__.py
+++ b/src/morphosamplers/models/__init__.py
@@ -1,1 +1,3 @@
-from .morphomodels import MorphoModels
+from .path import Path
+from .sphere import Sphere
+from .surface import Surface

--- a/src/morphosamplers/models/__init__.py
+++ b/src/morphosamplers/models/__init__.py
@@ -1,0 +1,1 @@
+from .morphomodels import MorphoModels

--- a/src/morphosamplers/models/morphomodels.py
+++ b/src/morphosamplers/models/morphomodels.py
@@ -1,9 +1,0 @@
-from .path import Path
-from .surface import Surface
-from .sphere import Sphere
-
-
-class MorphoModels:
-    Path = Path
-    Surface = Surface
-    Sphere = Sphere

--- a/src/morphosamplers/models/morphomodels.py
+++ b/src/morphosamplers/models/morphomodels.py
@@ -1,0 +1,9 @@
+from .path import Path
+from .surface import Surface
+from .sphere import Sphere
+
+
+class MorphoModels:
+    Path = Path
+    Surface = Surface
+    Sphere = Sphere

--- a/src/morphosamplers/models/path.py
+++ b/src/morphosamplers/models/path.py
@@ -1,0 +1,25 @@
+import numpy as np
+from pydantic import validator
+
+from morphosamplers.core import MorphoModel
+
+
+class Path(MorphoModel):
+    """A 3D path defined by an `(n, 3)` array of control points."""
+    control_points: np.ndarray
+
+    @validator('control_points', pre=True)
+    def coerce_to_n_by_3_array(cls, value):
+        value = np.atleast_2d(np.asarray(value))
+        if value.ndim != 2 or value.shape[-1] != 3:
+            raise ValueError('`control_points` must be an (n, 3) array.')
+        return value
+
+    @validator('control_points')
+    def check_at_least_two_points(cls, value):
+        if len(value) < 2:
+            raise ValueError('A Path must contain at least two points.')
+        return value
+
+    def __len__(self) -> int:
+        return len(self.control_points)

--- a/src/morphosamplers/models/sphere.py
+++ b/src/morphosamplers/models/sphere.py
@@ -1,0 +1,9 @@
+from typing import Tuple
+
+from morphosamplers.core import MorphoModel
+
+
+class Sphere(MorphoModel):
+    """A sphere in 3D."""
+    center: Tuple[float, float, float]
+    radius: float

--- a/src/morphosamplers/models/surface.py
+++ b/src/morphosamplers/models/surface.py
@@ -1,3 +1,5 @@
+from typing import List
+
 import numpy as np
 from pydantic import validator
 
@@ -6,7 +8,7 @@ from morphosamplers.core import MorphoModel
 
 class Surface(MorphoModel):
     """A 3D surface defined by control points in a series of levels."""
-    control_points: list[np.ndarray]
+    control_points: List[np.ndarray]
 
     @validator('control_points')
     def check_at_least_two_points(cls, value):

--- a/src/morphosamplers/models/surface.py
+++ b/src/morphosamplers/models/surface.py
@@ -1,0 +1,25 @@
+import numpy as np
+from pydantic import validator
+
+from morphosamplers.core import MorphoModel
+
+
+class Surface(MorphoModel):
+    """A 3D surface defined by control points in a series of levels."""
+    control_points: list[np.ndarray]
+
+    @validator('control_points')
+    def check_at_least_two_points(cls, value):
+        if len(value) < 2:
+            raise ValueError('A Path must contain at least two levels.')
+        for array in value:
+            if len(array) < 2:
+                raise ValueError('Each level must contain at least two points.')
+        return value
+
+    @validator('control_points', pre=True)
+    def ensure_list_of_float_arrays(cls, value):
+        return [np.asarray(v, dtype=np.float32) for v in value]
+
+    def __len__(self) -> int:
+        return len(self.control_points)

--- a/src/morphosamplers/sample_types.py
+++ b/src/morphosamplers/sample_types.py
@@ -1,6 +1,7 @@
 import numpy as np
 from pydantic import BaseModel, root_validator, validator
-from typing import TypeAlias, Union
+from typing import Union
+from typing_extensions import TypeAlias
 
 Image: TypeAlias = np.ndarray
 Mask: TypeAlias = np.ndarray

--- a/src/morphosamplers/sample_types.py
+++ b/src/morphosamplers/sample_types.py
@@ -1,0 +1,44 @@
+import numpy as np
+from pydantic import BaseModel, root_validator, validator
+from typing import TypeAlias, Union
+
+Image: TypeAlias = np.ndarray
+Mask: TypeAlias = np.ndarray
+Points: TypeAlias = np.ndarray  # (n, 3)
+
+
+class PoseSet(BaseModel):
+    """Model for a set of 3D poses."""
+    positions: np.ndarray  # (n, 3)
+    orientations: np.ndarray  # (n, 3, 3)
+
+    class Config:
+        allow_mutation = False
+        arbitrary_types_allowed = True
+
+    @validator('positions', pre=True)
+    def coerce_to_n_by_3_array(cls, value):
+        value = np.atleast_2d(np.asarray(value))
+        if value.ndim != 2 or value.shape[-1] != 3:
+            raise ValueError('positions must be an (n, 3) array.')
+        return value
+
+    @validator('orientations', pre=True)
+    def check_n_by_3_3_array(cls, value):
+        value = np.asarray(value)
+        if value.ndim != 3 or value.shape[-2:] != (3, 3):
+            raise ValueError('orientations must be an (n, 3, 3) array.')
+        return value
+
+    @root_validator
+    def check_same_length(cls, values):
+        positions, orientations = values.get('positions'), values.get('orientations')
+        if len(positions) != len(orientations):
+            raise ValueError("lengths of positions and orientations don't match")
+        return values
+
+    def __len__(self) -> int:
+        return len(self.positions)
+
+
+SampleType = Union[PoseSet, Image, Mask, Points]

--- a/src/morphosamplers/samplers/path_samplers/__init__.py
+++ b/src/morphosamplers/samplers/path_samplers/__init__.py
@@ -1,0 +1,3 @@
+from .point_sampler import PointSampler
+from .pose_sampler_parallel import PoseSampler
+from .pose_sampler_helical import HelicalPoseSampler

--- a/src/morphosamplers/samplers/path_samplers/point_sampler.py
+++ b/src/morphosamplers/samplers/path_samplers/point_sampler.py
@@ -1,3 +1,5 @@
+from typing import Tuple
+
 import einops
 import numpy as np
 from scipy.interpolate import splprep, splev
@@ -21,7 +23,7 @@ class PointSampler(MorphoSampler):
     @staticmethod
     def prepare_spline(
         path: Path, n_initial_samples: int = 10_000
-    ) -> tuple[tuple[...], float]:
+    ) -> Tuple[Tuple[...], float]:
         # oversample an initial spline between control points
         points = einops.rearrange(path.control_points, 'b xyz -> xyz b')
         u = np.linspace(0, 1, num=n_initial_samples)

--- a/src/morphosamplers/samplers/path_samplers/point_sampler.py
+++ b/src/morphosamplers/samplers/path_samplers/point_sampler.py
@@ -23,7 +23,7 @@ class PointSampler(MorphoSampler):
     @staticmethod
     def prepare_spline(
         path: Path, n_initial_samples: int = 10_000
-    ) -> Tuple[Tuple[...], float]:
+    ) -> Tuple[Tuple[np.ndarray], float]:
         # oversample an initial spline between control points
         points = einops.rearrange(path.control_points, 'b xyz -> xyz b')
         u = np.linspace(0, 1, num=n_initial_samples)

--- a/src/morphosamplers/samplers/path_samplers/point_sampler.py
+++ b/src/morphosamplers/samplers/path_samplers/point_sampler.py
@@ -1,0 +1,42 @@
+import einops
+import numpy as np
+from scipy.interpolate import splprep, splev
+
+from morphosamplers.core import MorphoSampler
+from morphosamplers.models import MorphoModels
+from morphosamplers.sample_types import Points
+
+
+class PointSampler(MorphoSampler):
+    spacing: float
+
+    def sample(self, obj: MorphoModels.Path) -> Points:
+        """Sample a `Path` to produces an `(n, 3)` array of points."""
+        tck, total_length = self.prepare_spline(obj)
+        n_samples = total_length // self.spacing
+        max_u = 1 - ((total_length % self.spacing) / total_length)
+        u = np.linspace(0, max_u, num=int(n_samples))
+        return einops.rearrange(splev(u, tck), 'xyz b -> b xyz')
+
+    @staticmethod
+    def prepare_spline(
+        path: MorphoModels.Path, n_initial_samples: int = 10_000
+    ) -> tuple[tuple[...], float]:
+        # oversample an initial spline between control points
+        points = einops.rearrange(path.control_points, 'b xyz -> xyz b')
+        u = np.linspace(0, 1, num=n_initial_samples)
+        spline_order = 3 if len(path) > 3 else len(path) - 1
+        tck, _ = splprep(points, s=0, k=spline_order)
+        samples = einops.rearrange(splev(u, tck), 'xyz b -> b xyz')
+
+        # calculate the cumulative length as we move along the path.
+        inter_point_differences = np.diff(samples, axis=0)
+        inter_point_distances = np.linalg.norm(inter_point_differences, axis=1)
+        cumulative_distance = np.cumsum(inter_point_distances)
+        total_length = float(cumulative_distance[-1])
+        cumulative_distance /= total_length  # normalise to unit length
+        cumulative_distance = np.insert(cumulative_distance, 0, 0)
+
+        # equidistant samples in u yield equidistant samples in euclidean space
+        tck, _ = splprep(samples.T, u=cumulative_distance, s=0, k=spline_order)
+        return tck, total_length

--- a/src/morphosamplers/samplers/path_samplers/point_sampler.py
+++ b/src/morphosamplers/samplers/path_samplers/point_sampler.py
@@ -2,15 +2,15 @@ import einops
 import numpy as np
 from scipy.interpolate import splprep, splev
 
+from morphosamplers import Path
 from morphosamplers.core import MorphoSampler
-from morphosamplers.models import MorphoModels
 from morphosamplers.sample_types import Points
 
 
 class PointSampler(MorphoSampler):
     spacing: float
 
-    def sample(self, obj: MorphoModels.Path) -> Points:
+    def sample(self, obj: Path) -> Points:
         """Sample a `Path` to produces an `(n, 3)` array of points."""
         tck, total_length = self.prepare_spline(obj)
         n_samples = total_length // self.spacing
@@ -20,7 +20,7 @@ class PointSampler(MorphoSampler):
 
     @staticmethod
     def prepare_spline(
-        path: MorphoModels.Path, n_initial_samples: int = 10_000
+        path: Path, n_initial_samples: int = 10_000
     ) -> tuple[tuple[...], float]:
         # oversample an initial spline between control points
         points = einops.rearrange(path.control_points, 'b xyz -> xyz b')

--- a/src/morphosamplers/samplers/path_samplers/pose_sampler_helical.py
+++ b/src/morphosamplers/samplers/path_samplers/pose_sampler_helical.py
@@ -2,7 +2,7 @@ import numpy as np
 from scipy.spatial.transform import Rotation as R
 
 from morphosamplers.core import MorphoSampler
-from morphosamplers.models import MorphoModels
+from morphosamplers.models import Path
 from morphosamplers.sample_types import PoseSet
 
 from .pose_sampler_parallel import PoseSampler
@@ -19,8 +19,7 @@ class HelicalPoseSampler(MorphoSampler):
     spacing: float  # spacing between positions
     twist: float  # helical twist per subunit in degrees
 
-
-    def sample(self, obj: MorphoModels.Path) -> PoseSet:
+    def sample(self, obj: Path) -> PoseSet:
         # get parallel poses along filament axis
         sampler = PoseSampler(spacing=self.spacing)
         poses = sampler.sample(obj)

--- a/src/morphosamplers/samplers/path_samplers/pose_sampler_helical.py
+++ b/src/morphosamplers/samplers/path_samplers/pose_sampler_helical.py
@@ -1,0 +1,32 @@
+import numpy as np
+from scipy.spatial.transform import Rotation as R
+
+from morphosamplers.core import MorphoSampler
+from morphosamplers.models import MorphoModels
+from morphosamplers.sample_types import PoseSet
+
+from .pose_sampler_parallel import PoseSampler
+
+
+class HelicalPoseSampler(MorphoSampler):
+    """Sample poses along the backbone of a helical path.
+
+    In the sample poses
+    - positions will be separated by `spacing`.
+    - z-axis at each position will be aligned with the filament axis
+    - xy-planes will be rotated by `twist` degrees between adjacent positions.
+    """
+    spacing: float  # spacing between positions
+    twist: float  # helical twist per subunit in degrees
+
+
+    def sample(self, obj: MorphoModels.Path) -> PoseSet:
+        # get parallel poses along filament axis
+        sampler = PoseSampler(spacing=self.spacing)
+        poses = sampler.sample(obj)
+
+        # rotate poses so they respect helical parameters
+        angles = np.linspace(start=0, stop=self.twist * len(poses), num=len(poses))
+        Rz = R.from_euler('z', angles=angles, degrees=True).as_matrix()
+        new_orientations = poses.orientations @ Rz
+        return PoseSet(positions=poses.positions, orientations=new_orientations)

--- a/src/morphosamplers/samplers/path_samplers/pose_sampler_parallel.py
+++ b/src/morphosamplers/samplers/path_samplers/pose_sampler_parallel.py
@@ -3,7 +3,7 @@ import numpy as np
 from scipy.interpolate import splev
 from scipy.spatial.transform import Rotation, Slerp
 
-from morphosamplers import MorphoModels
+from morphosamplers import Path
 from morphosamplers.core import MorphoSampler
 from morphosamplers.sample_types import PoseSet
 from morphosamplers.utils import coaxial_y_vectors_from_z_vectors
@@ -12,7 +12,7 @@ from morphosamplers.utils import coaxial_y_vectors_from_z_vectors
 class PoseSampler(MorphoSampler):
     spacing: float
 
-    def sample(self, obj: MorphoModels.Path) -> PoseSet:
+    def sample(self, obj: Path) -> PoseSet:
         """Sample a `Path` to produces a `PoseSet`.
 
         The positions in the `PoseSet` are equidistant points sampled according to

--- a/src/morphosamplers/samplers/path_samplers/pose_sampler_parallel.py
+++ b/src/morphosamplers/samplers/path_samplers/pose_sampler_parallel.py
@@ -1,0 +1,47 @@
+import einops
+import numpy as np
+from scipy.interpolate import splev
+from scipy.spatial.transform import Rotation, Slerp
+
+from morphosamplers import MorphoModels
+from morphosamplers.core import MorphoSampler
+from morphosamplers.sample_types import PoseSet
+from morphosamplers.utils import coaxial_y_vectors_from_z_vectors
+
+
+class PoseSampler(MorphoSampler):
+    spacing: float
+
+    def sample(self, obj: MorphoModels.Path) -> PoseSet:
+        """Sample a `Path` to produces a `PoseSet`.
+
+        The positions in the `PoseSet` are equidistant points sampled according to
+        `spacing`. The orientations in the `PoseSet` are as close to parallel to each
+        other as curvature of the path allows. The z-axis is oriented along a
+        smooth curve through the control points.
+        """
+        # sample equidistant points along path
+        from .point_sampler import PointSampler
+        tck, total_length = PointSampler.prepare_spline(obj)
+        n_samples = total_length // self.spacing
+        max_u = 1 - ((total_length % self.spacing) / total_length)
+        u = np.linspace(0, max_u, num=int(n_samples))
+        positions = einops.rearrange(splev(u, tck), 'xyz b -> b xyz')
+
+        # oversample orientations along path which are maximally coaxial (parallel)
+        u_oversampled = np.linspace(0, 1, num=5000)
+        z = einops.rearrange(splev(u_oversampled, tck, der=1), 'xyz b -> b xyz')
+        z /= np.linalg.norm(z, axis=-1, keepdims=True)
+        y = coaxial_y_vectors_from_z_vectors(z)
+        x = np.cross(y, z)
+        x /= np.linalg.norm(x, axis=-1, keepdims=True)
+        rotations = np.empty(shape=(5000, 3, 3))
+        rotations[:, :, 0] = x
+        rotations[:, :, 1] = y
+        rotations[:, :, 2] = z
+        # rotations = einops.rearrange([x, y, z], 'xyz b vec -> b vec xyz')
+
+        # interpolate rotations
+        rotation_sampler = Slerp(u_oversampled, Rotation.from_matrix(rotations))
+        orientations = rotation_sampler(u).as_matrix()
+        return PoseSet(positions=positions, orientations=orientations)

--- a/src/morphosamplers/samplers/path_samplers/tests/test_point_sampler_equidistant.py
+++ b/src/morphosamplers/samplers/path_samplers/tests/test_point_sampler_equidistant.py
@@ -1,0 +1,27 @@
+import einops
+import numpy as np
+
+from morphosamplers import PathSamplers
+from morphosamplers import MorphoModels
+
+
+def test_instantiation():
+    sampler = PathSamplers.PointSampler(spacing=5)
+    assert isinstance(sampler, PathSamplers.PointSampler)
+
+
+def test_sampling():
+    """Samples should interpolate control points"""
+    n_points = 50
+    total_length = 100
+    spacing = total_length / n_points
+    x = y = np.zeros(shape=(n_points, ))
+    z = np.linspace(0, total_length, num=n_points)
+    control_points = einops.rearrange([x, y, z], 'xyz b -> b xyz')
+    path = MorphoModels.Path(control_points=control_points)
+    sampler = PathSamplers.PointSampler(spacing=spacing)
+    samples = sampler.sample(path)
+    assert isinstance(samples, np.ndarray)
+    assert samples.ndim == 2
+    expected = np.linspace([0, 0, 0], [0, 0, total_length], num=n_points)
+    assert np.allclose(samples, expected)

--- a/src/morphosamplers/samplers/path_samplers/tests/test_pose_sampler_parallel.py
+++ b/src/morphosamplers/samplers/path_samplers/tests/test_pose_sampler_parallel.py
@@ -1,0 +1,45 @@
+import einops
+import numpy as np
+
+from morphosamplers.sample_types import PoseSet
+from morphosamplers.samplers.path_samplers import PathSamplers
+from morphosamplers.models import MorphoModels
+
+
+def test_instantiation():
+    sampler = PathSamplers.PoseSampler(spacing=5)
+    assert isinstance(sampler, PathSamplers.PoseSampler)
+
+
+def test_sampling():
+    """Samples should interpolate control points with consistent orientations."""
+    n_points = 50
+    total_length = 100
+    spacing = total_length / n_points
+    x = y = np.zeros(shape=(n_points, ))
+    z = np.linspace(0, total_length, num=n_points)
+    control_points = einops.rearrange([x, y, z], 'xyz b -> b xyz')
+    path = MorphoModels.Path(control_points=control_points)
+    sampler = PathSamplers.PoseSampler(spacing=spacing)
+    samples = sampler.sample(path)
+
+    # positions should be an interpolation along z from 0 -> total_length
+    assert isinstance(samples, PoseSet)
+    expected = np.linspace([0, 0, 0], [0, 0, total_length], num=n_points)
+    assert np.allclose(samples.positions, expected)
+
+    # z axis should be a unit vector along +z
+    z = samples.orientations[:, :, 2]
+    assert np.allclose(z, [0, 0, 1])
+
+    # y0 and y1 should be ~identical unit vectors...
+    y0 = samples.orientations[0, :, 1]
+    y1 = samples.orientations[1, :, 1]
+    projection = np.dot(y0, y1)
+    assert np.allclose(np.linalg.norm(y0), 1)
+    assert np.allclose(np.linalg.norm(y1), 1)
+    assert np.allclose(projection, 1)
+
+    # check for determinant 1 on all rotation matrices
+    determinants = np.linalg.det(samples.orientations)
+    assert np.allclose(determinants, 1)

--- a/src/morphosamplers/samplers/sphere_samplers/__init__.py
+++ b/src/morphosamplers/samplers/sphere_samplers/__init__.py
@@ -1,0 +1,2 @@
+from .point_sampler import PointSampler
+from .pose_sampler import PoseSampler

--- a/src/morphosamplers/samplers/sphere_samplers/_sphere_utils.py
+++ b/src/morphosamplers/samplers/sphere_samplers/_sphere_utils.py
@@ -1,0 +1,30 @@
+import numpy as np
+import einops
+
+GOLDEN_RATIO = (1 + np.sqrt(5)) / 2
+
+# calculate using calculate_best_fit_parameters in dev/sphere_params.py
+A = 0.07726122
+B = 0.02657319
+
+
+def fibonacci_sphere(n):
+    # http://extremelearning.com.au/how-to-evenly-distribute-points-on-a-
+    # sphere-more-effectively-than-the-canonical-fibonacci-lattice/
+    i = np.arange(n)
+    phi = 2 * np.pi * i / GOLDEN_RATIO
+    # this is the version that optimizes for mean distance
+    eps = 0.36
+    theta = np.arccos(1 - 2 * (i + eps) / (n - 1 + 2 * eps))
+    x = np.cos(phi) * np.sin(theta)
+    y = np.sin(phi) * np.sin(theta)
+    z = np.cos(theta)
+    return einops.rearrange([x, y, z], 'xyz b -> b xyz')
+
+
+def spacing_from_n(n):
+    return 1 / np.sqrt(A * n + B)
+
+
+def n_from_spacing(spacing):
+    return int(1 / (spacing ** 2 * A) - B / A)

--- a/src/morphosamplers/samplers/sphere_samplers/point_sampler.py
+++ b/src/morphosamplers/samplers/sphere_samplers/point_sampler.py
@@ -1,0 +1,16 @@
+import numpy as np
+
+from morphosamplers.core import MorphoSampler
+from morphosamplers import MorphoModels
+
+from ._sphere_utils import fibonacci_sphere, n_from_spacing
+
+
+class PointSampler(MorphoSampler):
+    spacing: float
+
+    def sample(self, obj: MorphoModels.Sphere) -> np.ndarray:
+        n = n_from_spacing(self.spacing / obj.radius)
+        return fibonacci_sphere(n) * obj.radius + np.asarray(obj.center)
+
+

--- a/src/morphosamplers/samplers/sphere_samplers/point_sampler.py
+++ b/src/morphosamplers/samplers/sphere_samplers/point_sampler.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 from morphosamplers.core import MorphoSampler
-from morphosamplers import MorphoModels
+from morphosamplers import Sphere
 
 from ._sphere_utils import fibonacci_sphere, n_from_spacing
 
@@ -9,7 +9,7 @@ from ._sphere_utils import fibonacci_sphere, n_from_spacing
 class PointSampler(MorphoSampler):
     spacing: float
 
-    def sample(self, obj: MorphoModels.Sphere) -> np.ndarray:
+    def sample(self, obj: Sphere) -> np.ndarray:
         n = n_from_spacing(self.spacing / obj.radius)
         return fibonacci_sphere(n) * obj.radius + np.asarray(obj.center)
 

--- a/src/morphosamplers/samplers/sphere_samplers/pose_sampler.py
+++ b/src/morphosamplers/samplers/sphere_samplers/pose_sampler.py
@@ -1,0 +1,35 @@
+import numpy as np
+from scipy.spatial.transform import Rotation as R
+
+from morphosamplers.core import MorphoSampler
+from morphosamplers import MorphoModels
+from morphosamplers.sample_types import PoseSet
+from morphosamplers.samplers.sphere_samplers.point_sampler import PointSampler
+
+
+class PoseSampler(MorphoSampler):
+    """Sample poses packed on the surface of a sphere with a defined spacing."""
+    spacing: float
+
+    def sample(self, obj: MorphoModels.Sphere) -> PoseSet:
+        # get equally spaced points on surface
+        point_sampler = PointSampler(spacing=self.spacing)
+        positions = point_sampler.sample(obj)
+
+        # get some initial orientation with z normal to the surface
+        z_vectors = positions - np.asarray(obj.center)
+        z_vectors /= np.linalg.norm(z_vectors, axis=-1, keepdims=True)
+        y_vectors = np.cross(z_vectors, [1, 1, 1])
+        y_vectors /= np.linalg.norm(y_vectors, axis=-1, keepdims=True)
+        x_vectors = np.cross(y_vectors, z_vectors)
+        x_vectors /= np.linalg.norm(x_vectors, axis=-1, keepdims=True)
+        orientations = np.empty(shape=(len(positions), 3, 3), dtype=np.float32)
+        orientations[:, :, 0] = x_vectors
+        orientations[:, :, 1] = y_vectors
+        orientations[:, :, 2] = z_vectors
+
+        # randomise in plane rotation
+        angles = np.random.uniform(0, 360, size=(len(positions)))
+        Rz = R.from_euler('z', angles=angles, degrees=True).as_matrix()
+        orientations = orientations @ Rz
+        return PoseSet(positions=positions, orientations=orientations)

--- a/src/morphosamplers/samplers/sphere_samplers/pose_sampler.py
+++ b/src/morphosamplers/samplers/sphere_samplers/pose_sampler.py
@@ -2,7 +2,7 @@ import numpy as np
 from scipy.spatial.transform import Rotation as R
 
 from morphosamplers.core import MorphoSampler
-from morphosamplers import MorphoModels
+from morphosamplers import Sphere
 from morphosamplers.sample_types import PoseSet
 from morphosamplers.samplers.sphere_samplers.point_sampler import PointSampler
 
@@ -11,7 +11,7 @@ class PoseSampler(MorphoSampler):
     """Sample poses packed on the surface of a sphere with a defined spacing."""
     spacing: float
 
-    def sample(self, obj: MorphoModels.Sphere) -> PoseSet:
+    def sample(self, obj: Sphere) -> PoseSet:
         # get equally spaced points on surface
         point_sampler = PointSampler(spacing=self.spacing)
         positions = point_sampler.sample(obj)

--- a/src/morphosamplers/samplers/sphere_samplers/tests/test_point_sampler.py
+++ b/src/morphosamplers/samplers/sphere_samplers/tests/test_point_sampler.py
@@ -1,0 +1,42 @@
+import numpy as np
+from scipy.spatial import KDTree
+
+from morphosamplers import MorphoModels
+from morphosamplers.samplers import sphere_samplers
+
+
+def test_point_sampler():
+    """Should produce points with correct spacing on surface of sphere."""
+    sphere = MorphoModels.Sphere(center=(5, 5, 5), radius=10)
+    sampler = sphere_samplers.PointSampler(spacing=2)
+    points = sampler.sample(sphere)
+
+    # all points should be centered around (5, 5, 5)
+    eps = 1e-2
+    assert np.mean(points) - 5 < eps
+
+    # spacing between points should be ~2
+    tree = KDTree(points)
+    distances, idx = tree.query(points, k=4)
+    distances = distances[:, 1:]  # exclude distance to self
+    assert 1.75 <= np.mean(distances) < 2.25
+
+
+def test_pose_sampler():
+    """Should produce poses oriented with Z normal to the surface of the sphere."""
+    sphere = MorphoModels.Sphere(center=(5, 5, 5), radius=10)
+    sampler = sphere_samplers.PoseSampler(spacing=2)
+    poses = sampler.sample(sphere)
+
+    # all points should be centered around (5, 5, 5)
+    eps = 1e-2
+    assert np.mean(poses.positions) - 5 < eps
+
+    # points should be oriented with z normal to the sphere
+    z_vecs_poses = poses.orientations[:, :, 2]
+    z_dir_expected = poses.positions - np.array([5, 5, 5])
+    z_dir_expected /= np.linalg.norm(z_dir_expected, axis=-1, keepdims=True)
+    assert np.allclose(z_vecs_poses, z_dir_expected)
+
+    # check that rotation matrices are in SO3
+    assert np.allclose(np.linalg.det(poses.orientations), 1)

--- a/src/morphosamplers/spline.py
+++ b/src/morphosamplers/spline.py
@@ -9,7 +9,7 @@ from pydantic import PrivateAttr, conint, root_validator, validator
 from scipy.interpolate import splev, splprep
 from scipy.spatial.transform import Rotation, Slerp
 
-from .utils import calculate_y_vectors_from_z_vectors, within_range, get_mask_limits
+from .utils import coaxial_y_vectors_from_z_vectors, within_range, get_mask_limits
 
 
 class NDimensionalSpline(EventedModel):
@@ -247,16 +247,16 @@ class Spline3D(NDimensionalSpline):
         self._prepare_orientation_sampler()
 
     def _prepare_orientation_sampler(self):
-        """Prepare a sampler yielding smoothly varying orientations along the spline.
+        """Prepare a pose_sampler yielding smoothly varying orientations along the spline.
 
         This method constructs a set of rotation matrices which vary smoothly with
-        the spline coordinate `u`. A sampler is then prepared which can be queried at
+        the spline coordinate `u`. A pose_sampler is then prepared which can be queried at
         any point(s) along the spline coordinate `u` and the resulting rotations vary
         smoothly along the spline
         """
         u = np.linspace(0, 1, num=self._n_spline_samples)
         z = self._sample_spline_z(u)
-        y = calculate_y_vectors_from_z_vectors(z)
+        y = coaxial_y_vectors_from_z_vectors(z)
         x = np.cross(y, z)
         r = Rotation.from_matrix(np.stack([x, y, z], axis=-1))
         self._rotation_sampler = Slerp(u, r)

--- a/src/morphosamplers/utils.py
+++ b/src/morphosamplers/utils.py
@@ -21,7 +21,7 @@ def _project_vector_onto_plane(vector, plane_normal):
     return proj_plane
 
 
-def calculate_y_vectors_from_z_vectors(
+def coaxial_y_vectors_from_z_vectors(
     z: np.ndarray,
     initial_y_vector: Union[np.ndarray, Tuple[float, float, float]] = (0.3234, 0.6543, 0.978),
 ) -> np.ndarray:
@@ -53,7 +53,7 @@ def calculate_y_vectors_from_z_vectors(
     if np.dot(initial_y_vector, z[0]) == 1:
         raise ValueError('cannot generate y vectors because the provided initial_y_vector '
                          'and the first z vector are perfectly aligned.')
-    # normalise initial y vector so that dot product is the projection
+    # normalise initial y vector so that the subsequent dot product is a projection
     initial_y_vector = initial_y_vector / np.linalg.norm(initial_y_vector)
 
     # initialise first y

--- a/tests/test_spline_model.py
+++ b/tests/test_spline_model.py
@@ -137,7 +137,7 @@ def test_spline_orientations():
     spline = Spline3D(points=points, order=3)
     pt = spline.sample(u=0)
     # lower atol, as it's very strict by default, much more than np.allclose
-    np.testing.assert_allclose(pt, 0, atol=1e-20)
+    np.testing.assert_allclose(pt, 0, atol=1e-8)
     ori = spline.sample_orientations(u=0)
     np.testing.assert_allclose(ori.apply([0, 0, 1]), [[0, 0, 1]])
 


### PR DESCRIPTION
this PR moves the `Path` and `Sphere` models to a new API where we have `MorphoModels` and `MorphoSamplers`

- models contain some simple representation of an underlying geometry
- samplers contain the parameters relevant to sampling a geometry

general pattern

```python
model = Model(bla=bla, bla2=bla2)
sampler = Sampler(bla3=bla3)
samples = sampler.sample(model)
```

