### PR TITLE
Fix a few issues with spacing and oversampling

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,42 +7,42 @@ default_install_hook_types: [pre-commit, commit-msg]
 
 repos:
   - repo: https://github.com/compilerla/conventional-pre-commit
-    rev: v1.3.0
+    rev: v2.4.0
     hooks:
       - id: conventional-pre-commit
         stages: [commit-msg]
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v4.5.0
     hooks:
       - id: check-docstring-first
       - id: end-of-file-fixer
       - id: trailing-whitespace
 
   - repo: https://github.com/myint/autoflake
-    rev: v1.4
+    rev: v2.2.1
     hooks:
       - id: autoflake
         args: ["--in-place", "--remove-all-unused-imports"]
 
   - repo: https://github.com/PyCQA/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
 
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.34.0
+    rev: v3.15.0
     hooks:
       - id: pyupgrade
         args: [--py38-plus, --keep-runtime-typing]
 
   - repo: https://github.com/psf/black
-    rev: 22.3.0
+    rev: 23.9.1
     hooks:
       - id: black
 
   - repo: https://github.com/PyCQA/flake8
-    rev: 4.0.1
+    rev: 6.1.0
     hooks:
       - id: flake8
         args:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,16 +93,27 @@ src_paths = ["src/morphosamplers", "tests"]
 [tool.flake8]
 exclude = "docs,.eggs,examples,_version.py"
 max-line-length = 88
-ignore = "E203"
 min-python-version = "3.8.0"
 docstring-convention = "all" # use numpy convention, while allowing D417
-extend-ignore = """
-E203  # whitespace before ':'
-D107,D203,D212,D213,D402,D413,D415,D416  # numpy
-D100  # missing docstring in public module
-D401  # imperative mood
-W503  # line break before binary operator
-"""
+ignore = [
+    # whitespace before ':'
+    "E203",
+    # numpy
+    "D107",
+    "D203",
+    "D212",
+    "D213",
+    "D402",
+    "D413",
+    "D415",
+    "D416",
+    # missing docstring in public module
+    "D100",
+    # imperative mood
+    "D401",
+    # line break before binary operator
+    "W503",
+]
 per-file-ignores = [
     "tests/*:D",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "einops",
     "numpy",
     "psygnal",
-    "pydantic",
+    "pydantic<2",
     "scipy",
     "typing-extensions"
 ]

--- a/src/morphosamplers/surface_spline.py
+++ b/src/morphosamplers/surface_spline.py
@@ -313,17 +313,22 @@ class GriddedSplineSurface(_SplineSurface):
         rows, columns = self.grid_shape
         row_range = np.arange(rows)
         column_range = np.arange(columns)
+        shift = 0
+        if self.closed:
+            columns += 1
+            shift = 1
+            column_range = np.append(column_range, 0)
 
         # first half of triangles
-        first_index = np.repeat(row_range[:-1], columns - 1) * columns + np.tile(column_range[:-1], rows - 1)
-        second_index = np.repeat(row_range[1:], columns - 1) * columns + np.tile(column_range[:-1], rows - 1)
-        third_index = np.repeat(row_range[:-1], columns - 1) * columns + np.tile(column_range[1:], rows - 1)
+        first_index = np.repeat(row_range[:-1], columns - 1) * (columns - shift) + np.tile(column_range[:-1], rows - 1)
+        second_index = np.repeat(row_range[1:], columns - 1) * (columns - shift) + np.tile(column_range[:-1], rows - 1)
+        third_index = np.repeat(row_range[:-1], columns - 1) * (columns - shift) + np.tile(column_range[1:], rows - 1)
         triangles_1 = np.stack([first_index, second_index, third_index], axis=1)
 
         # second half
-        first_index = np.repeat(row_range[1:], columns - 1) * columns + np.tile(column_range[:-1], rows - 1)
-        second_index = np.repeat(row_range[1:], columns - 1) * columns + np.tile(column_range[1:], rows - 1)
-        third_index = np.repeat(row_range[:-1], columns - 1) * columns + np.tile(column_range[1:], rows - 1)
+        first_index = np.repeat(row_range[1:], columns - 1) * (columns - shift) + np.tile(column_range[:-1], rows - 1)
+        second_index = np.repeat(row_range[1:], columns - 1) * (columns - shift) + np.tile(column_range[1:], rows - 1)
+        third_index = np.repeat(row_range[:-1], columns - 1) * (columns - shift) + np.tile(column_range[1:], rows - 1)
         triangles_2 = np.stack([first_index, second_index, third_index], axis=1)
 
         all_triangles = np.concatenate([triangles_1, triangles_2])

--- a/src/morphosamplers/utils.py
+++ b/src/morphosamplers/utils.py
@@ -1,7 +1,7 @@
 """Utility functions."""
 
-from typing import Tuple, Union
 import warnings
+from typing import Tuple, Union
 
 import numpy as np
 from scipy.spatial import KDTree
@@ -23,7 +23,11 @@ def _project_vector_onto_plane(vector, plane_normal):
 
 def calculate_y_vectors_from_z_vectors(
     z: np.ndarray,
-    initial_y_vector: Union[np.ndarray, Tuple[float, float, float]] = (0.3234, 0.6543, 0.978),
+    initial_y_vector: Union[np.ndarray, Tuple[float, float, float]] = (
+        0.3234,
+        0.6543,
+        0.978,
+    ),
 ) -> np.ndarray:
     """Calculate y vectors starting from z vectors.
 
@@ -51,8 +55,10 @@ def calculate_y_vectors_from_z_vectors(
     y = np.empty((len(z), 3))
 
     if np.dot(initial_y_vector, z[0]) == 1:
-        raise ValueError('cannot generate y vectors because the provided initial_y_vector '
-                         'and the first z vector are perfectly aligned.')
+        raise ValueError(
+            "cannot generate y vectors because the provided initial_y_vector "
+            "and the first z vector are perfectly aligned."
+        )
     # normalise initial y vector so that dot product is the projection
     initial_y_vector = initial_y_vector / np.linalg.norm(initial_y_vector)
 
@@ -91,7 +97,7 @@ def deduplicate_points(coords: np.ndarray, exclusion_radius: float) -> np.ndarra
     return coords
 
 
-def minimize_closed_point_strips_pair_distance(strips, expected_dist=None):
+def minimize_closed_point_row_pair_distance(strips, expected_dist=None):
     # assume closed, circular strips with equal length
     result = [strips[0]]
     ln = len(strips[0])
@@ -105,7 +111,10 @@ def minimize_closed_point_strips_pair_distance(strips, expected_dist=None):
                 best_dist = avg_dist
                 best_arr = next_rolled
         if expected_dist is not None and best_dist >= expected_dist * np.sqrt(2):
-            warnings.warn('The grid is sheared by more than 1 separation in some places', stacklevel=2)
+            warnings.warn(
+                "The grid is sheared by more than 1 separation in some places",
+                stacklevel=2,
+            )
         result.append(best_arr)
     return result
 
@@ -184,7 +193,10 @@ def minimize_point_row_pair_distance(rows, expected_dist=None):
                 best_roll_idx = i
 
         if expected_dist is not None and best_dist >= expected_dist * np.sqrt(2):
-            warnings.warn('The grid is sheared by more than 1 separation in some places', stacklevel=2)
+            warnings.warn(
+                "The grid is sheared by more than 1 separation in some places",
+                stacklevel=2,
+            )
 
         # we have the offset that minimises distances
         offset = best_roll_idx - len(next)
@@ -198,7 +210,10 @@ def minimize_point_row_pair_distance(rows, expected_dist=None):
     max_idx = max(o + len(a) for o, a in zip(offsets, rows))
     for arr, offset in zip(rows, offsets):
         padded = np.pad(
-            arr, ((offset - min_idx, max_idx - offset - len(arr)), (0, 0)), mode='constant', constant_values=np.nan
+            arr,
+            ((offset - min_idx, max_idx - offset - len(arr)), (0, 0)),
+            mode="constant",
+            constant_values=np.nan,
         )
         aligned.append(padded)
     return aligned


### PR DESCRIPTION
The diff is a big bigger than necessary cause I enabled some pre-commit fixes; The bottom line though is this:

- `oversample` is now exposed so it can be set depending on the use. 10 was actually overkill for many applications, so 2 is a better default since the whole point of it is to avoid edge cases where dividing integers by a non-divisor ends up to half a `separation` away from the real optimal position.
- `oversample` is now also used to fix the same issue along the "column" direction, in addition to the rows

This also fixed the hex grid.