### PR TITLE
Fix masking for grids

### DIFF
--- a/src/morphosamplers/spline.py
+++ b/src/morphosamplers/spline.py
@@ -22,6 +22,7 @@ class NDimensionalSpline(EventedModel):
     closed: bool = False
     _n_spline_samples: int = PrivateAttr(10000)
     _tck = PrivateAttr(Tuple)
+    _raw_u = PrivateAttr(np.ndarray)
     _u_mask_limits: List[Tuple[float, float]] = PrivateAttr([])
     _length = PrivateAttr(float)
 
@@ -89,7 +90,7 @@ class NDimensionalSpline(EventedModel):
         else:
             points = self.points
 
-        tck, raw_u = splprep(points.T, s=0, k=self.order, per=self.closed)
+        tck, self._raw_u = splprep(points.T, s=0, k=self.order, per=self.closed)
         samples = np.stack(splev(u, tck), axis=1)
 
         # calculate the cumulative length of line segments
@@ -107,7 +108,7 @@ class NDimensionalSpline(EventedModel):
             limits = get_mask_limits(self.mask)
             u_ranges = []
             for low_idx, high_idx in limits:
-                u_low, u_high = raw_u[[low_idx, high_idx]]
+                u_low, u_high = self._raw_u[[low_idx, high_idx]]
                 u_ranges.append((u_low, u_high))
             self._u_mask_limits = u_ranges
 


### PR DESCRIPTION
When I first implemented masking for surfaces (i.e: only return samples "within" the manually annotated area instead of the full rectangular grid) I did not do any interpolation along the column dimension of the grid. This resulted in choppy staircase-like annotations.

This PR adds a new step in the spline-grid generation, which linearly interpolates the original masks along the column dimension, so that each row has its own interpolated mask. Below is a comparison between main and this pr with a staircase-like annotation.

I also added some useful debugging methods to generate row and column samples only, which I use to display the interpolated manual annotation in cyan in the new image (but the annotation is the same for both)

![image](https://github.com/morphometrics/morphosamplers/assets/23482191/22cf3d19-b633-4594-ab16-90090fd43d94)
![image](https://github.com/morphometrics/morphosamplers/assets/23482191/f1ceea49-071d-4581-a819-c9d45d543d44)

```python
import napari
import numpy as np
from morphosamplers.surface_spline import GriddedSplineSurface, HexSplineSurface

v = napari.Viewer(ndisplay=3)
lines = np.load('surface.npy')  # this is the manual annotation
grid = HexSplineSurface(points=list(lines), separation=50)
v.add_points(grid.sample(), size=5)
row = grid._sample_rows()  # interpolated manual annotation
v.add_points(np.concatenate(row), face_color='cyan')
masked = grid.sample()[grid.mask]
v.add_points(masked, face_color='orange')
```


Note that initially I thought I could use `scipy.interpolate.griddata` to do the grid in one fell swoop, but it turns out that 2D interpolation does no really do the right job here, where we really want only one dimension to be interpolated.
