### PR TITLE
Fix inverted dims in mask

### DIFF
--- a/src/morphosamplers/surface_spline.py
+++ b/src/morphosamplers/surface_spline.py
@@ -251,7 +251,7 @@ class GriddedSplineSurface(_SplineSurface):
         begins_interp = interp1d(mean_raw_u, mask_begins)(u).round().astype(int)
         ends_interp = interp1d(mean_raw_u, mask_ends)(u).round().astype(int)
 
-        grid_mask = np.zeros((len(self._column_splines), len(u)), dtype=bool)
+        grid_mask = np.zeros((len(u), len(self._column_splines)), dtype=bool)
         for i, (b, e) in enumerate(zip(begins_interp, ends_interp)):
             grid_mask[i, b:e] = True
 
@@ -428,7 +428,7 @@ class HexSplineSurface(_SplineSurface):
         begins_interp = interp1d(mean_raw_u, mask_begins)(us[1]).round().astype(int)
         ends_interp = interp1d(mean_raw_u, mask_ends)(us[1]).round().astype(int)
 
-        grid_mask = np.zeros((len(self._column_splines), len(us[1])), dtype=bool)
+        grid_mask = np.zeros((len(us[1]), len(self._column_splines)), dtype=bool)
         for i, (b, e) in enumerate(zip(begins_interp, ends_interp)):
             grid_mask[i, b:e] = True
 


### PR DESCRIPTION
Quick fix for #29. Somehow, my random manual test ended up having a perfectly square grid, which made me miss this swap :P

example on non-square grid:
![image](https://github.com/morphometrics/morphosamplers/assets/23482191/68a41a6d-1db7-4003-9c6e-ef9f46bf1d97)
