### PR TITLE
[Maint] Fix pydantic-compat in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "pydantic",
     "pydantic-compat",
     "scipy",
-    "typing-extensions"
+    "typing_extensions"
 ]
 
 # extras

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "numpy",
     "psygnal",
     "pydantic",
-    "pydantic_compat ",
+    "pydantic-compat",
     "scipy",
     "typing-extensions"
 ]


### PR DESCRIPTION
Gah, it still works with pip with the underscore, but not when the conda-forge bots run.
In this PR I fix the name of the package and delete the extra space!
While I'm here, I fixed `typing_extensions`.
